### PR TITLE
Detect pcre using pkg-config

### DIFF
--- a/configure
+++ b/configure
@@ -1,9 +1,0 @@
-#!/bin/sh
-#
-
-# subst standard header path variables
-if test -n "$CPPFLAGS" ; then
-    echo "Found CPPFLAGS in environment: '$CPPFLAGS'"
-    sed 's,@CPPFLAGS@,'"$CPPFLAGS"',g;s,@LDFLAGS@,'"$LDFLAGS"',g'  \
-        < pcre-light.buildinfo.in > pcre-light.buildinfo
-fi

--- a/pcre-light.cabal
+++ b/pcre-light.cabal
@@ -18,7 +18,7 @@ copyright:       (c) 2007-2010. Don Stewart <dons@galois.com>
 author:          Don Stewart
 maintainer:      Daniel Díaz <dhelta.diaz@gmail.com>
 cabal-version: >= 1.2.0
-build-type:      Configure
+build-type:      Simple
 tested-with:     GHC == 7.8.3
 extra-source-files: configure, pcre-light.buildinfo.in, README.md
 extra-tmp-files:    pcre-light.buildinfo
@@ -39,5 +39,5 @@ library
     else
         build-depends: base >= 3 && <= 5, bytestring >= 0.9
 
-    extra-libraries: pcre
+    pkgconfig-depends: libpcre
 


### PR DESCRIPTION
The current approach uses `extra-libraries` and a `configure` script, which makes this package difficult to install on Windows since you need to specify where `libpcre` lives manually using the `--extra-lib-dirs` flag.

Instead, we can use `pkg-config`, which automatically configures the right linker and include flags and completely eliminates the need for a `configure script`. As a result, this fixes #2, since that issue becomes moot.

I've tested this on 64-bit Windows using GHC 7.10.3-rc1 and MSYS2 (and the `mingw-w64-x86_64-pcre` package). This should work on every other major OS as well, since they all have `pkg-config` configurations available for `libpcre`.