### PR TITLE
Add captureNames function to extract named subpatterns

### DIFF
--- a/Text/Regex/PCRE/Light/Char8.hs
+++ b/Text/Regex/PCRE/Light/Char8.hs
@@ -22,6 +22,7 @@ module Text.Regex.PCRE.Light.Char8 (
         -- * String interface
         , compile, compileM
         , match
+        , captureNames
 
         -- * Regex types and constructors externally visible
 
@@ -69,7 +70,7 @@ module Text.Regex.PCRE.Light.Char8 (
 
 import qualified Data.ByteString.Char8 as S
 import qualified Text.Regex.PCRE.Light as S
-import Text.Regex.PCRE.Light hiding (match, compile, compileM)
+import Text.Regex.PCRE.Light hiding (match, compile, compileM, captureNames)
 
 -- | 'compile'
 --
@@ -203,3 +204,11 @@ match r subject os =
            Nothing -> Nothing
            Just x  -> Just (map S.unpack x)
 {-# INLINE match #-}
+
+
+-- | 'captureNames'
+--
+-- Returns the names and numbers of all named subpatterns in the regular
+-- expression. The list is in alphabetical order.
+captureNames :: Regex -> [(String, Int)]
+captureNames r = map (\(n,i) -> (S.unpack n, i)) $ S.captureNames r


### PR DESCRIPTION
This is a useful feature of PCRE (and most other regex libs). E.g.

```haskell
> captureNames (compile "(?<date>(?<year>(\\d\\d)?\\d\\d)-(?<month>\\d\\d)-(?<day>\\d\\d))" [])
[("date",1),("day",5),("month",4),("year",2)]
```