### PR TITLE
Replace finalizerFree with c_pcre_free

### DIFF
--- a/Text/Regex/PCRE/Light.hs
+++ b/Text/Regex/PCRE/Light.hs
@@ -208,7 +208,7 @@ compileM str os = unsafePerformIO $
                 err <- peekCString =<< peek errptr
                 return (Left err)
             else do
-                reg <- newForeignPtr finalizerFree pcre_ptr -- release with free()
+                reg <- newForeignPtr c_pcre_free pcre_ptr
                 return (Right (Regex reg str))
 
 -- Possible improvements: an 'IsString' instance could be defined

--- a/Text/Regex/PCRE/Light/Base.hsc
+++ b/Text/Regex/PCRE/Light/Base.hsc
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, ForeignFunctionInterface, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface, CApiFFI #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 --------------------------------------------------------------------
 -- |
 -- Module   : Text.Regex.PCRE.Light.Base
@@ -25,6 +26,7 @@ module Text.Regex.PCRE.Light.Base (
         , c_pcre_compile
         , c_pcre_exec
         , c_pcre_fullinfo
+        , c_pcre_free
 
         ------------------------------------------------------------------------
 
@@ -823,4 +825,8 @@ foreign import ccall unsafe "pcre.h pcre_fullinfo"
                     -> PCREInfo
                     -> Ptr a
                     -> IO CInt
+
+-- | Return pcre_free finalizer
+foreign import capi "pcre.h value pcre_free"
+    c_pcre_free :: FinalizerPtr a
 


### PR DESCRIPTION
I want to use this library with custom allocator (Nginx pool allocator) which substitutes `pcre_malloc` and `pcre_free` function pointers with custom functions. Currently, *pcre-ligh*t calls `finalizerFree` unconditionally, which makes my module crash when the compiled regexes get deleted.

This fix provides correct replacement of `finalizerFree` with the actual finalizer stored in `pcre_free`. Notice that it uses GHC extension `CApiFFI` available since GHC 7.10 as the older *ccall* api is unable to correctly pull the finalizer from a C function pointer (`pcre_free`).

Notice also that GHC may throw a warning (my GHC version is 8.8.4)

```
[1 of 3] Compiling Text.Regex.PCRE.Light.Base ( dist/build/Text/Regex/PCRE/Light/Base.hs, dist/build/Text/Regex/PCRE/Light/Base.o )

Text/Regex/PCRE/Light/Base.hsc:830:1: warning: [-Wdodgy-foreign-imports]
    possible missing & in foreign import of FunPtr
    |
830 | foreign import capi "pcre.h value pcre_free"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

This can be safely ignored as `pcre_free` *is not* a function, but a function pointer, and GHC thinks by some reason (perhaps historically) that the only type of values that can be pulled from a C code with foreign import is a function.

I also tested that the correct finalizer gets called when the compiled regexes get deleted.